### PR TITLE
fix for issue #7 to consume the stream in a redirect scenario. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,10 @@ for (var protocol in protocols) {
             return redirect.userCallback(res);
           }
 
+          // we are going to follow the redirect, but in node 0.10 we must first attach a data listener
+          // to consume the stream and send the 'end' event
+          res.on('data', function() {});
+
           // save the original clientRequest to our redirectOptions so we can emit errors later
 
           // need to use url.resolve() in case location is a relative URL


### PR DESCRIPTION
this is required for node 0.8.x -> 0.10.x API changes to end the initial request. 

Node docs state: "If you don't consume the data, then streams will sit in a paused state forever, and the end event will never happen."
