### PR TITLE
Move event binding into RedirectableRequest function

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,6 @@ var SAFE_METHODS = { GET: true, HEAD: true, OPTIONS: true, TRACE: true };
 
 // Create handlers that pass events from native requests
 var eventHandlers = Object.create(null);
-["abort", "aborted", "error", "socket", "timeout"].forEach(function (event) {
-  eventHandlers[event] = function (arg) {
-    this._redirectable.emit(event, arg);
-  };
-});
 
 // An HTTP(S) request that can be redirected
 function RedirectableRequest(options, responseCallback) {
@@ -63,6 +58,12 @@ function RedirectableRequest(options, responseCallback) {
       options.pathname = options.path.substring(0, searchPos);
       options.search = options.path.substring(searchPos);
     }
+
+    ["abort", "aborted", "error", "socket", "timeout"].forEach(function (event) {
+      eventHandlers[event] = function (arg) {
+        self.emit(event, arg);
+      };
+    });
   }
 
   // Perform the first request


### PR DESCRIPTION
We are running into `emit` issue:
```
TypeError: Cannot read property 'emit' of undefined
      at eventHandlers.(anonymous function) (/home/circleci/st2client/node_modules/follow-redirects/index.js:16:24)
      at OverriddenClientRequest.RequestOverrider.req.once.req.on (/home/circleci/st2client/node_modules/nock/lib/request_overrider.js:172:7)
      at RedirectableRequest._performRequest (/home/circleci/st2client/node_modules/follow-redirects/index.js:177:15)
      at new RedirectableRequest (/home/circleci/st2client/node_modules/follow-redirects/index.js:66:8)
      at Object.wrappedProtocol.request (/home/circleci/st2client/node_modules/follow-redirects/index.js:307:14)
      at dispatchHttpRequest (/home/circleci/st2client/node_modules/axios/lib/adapters/http.js:180:25)
      at new Promise (<anonymous>)
      at httpAdapter (/home/circleci/st2client/node_modules/axios/lib/adapters/http.js:20:10)
      at dispatchRequest (/home/circleci/st2client/node_modules/axios/lib/core/dispatchRequest.js:59:10)
      at <anonymous>
```
When running our tests for [st2client.js PR 68](https://github.com/StackStorm/st2client.js/pull/68), failed on Circle CI: https://circleci.com/gh/StackStorm/st2client.js/66

We found commit where these code moved outside of `RedirectableRequest` constructor and we moved back to avoid conflict with `socket` event.