### PR TITLE
Handle native request errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,8 +237,14 @@ RedirectableRequest.prototype._performRequest = function () {
   }
 
   // Create the native request
-  var request = this._currentRequest =
+  var request;
+  try {
+    request = this._currentRequest =
         nativeProtocol.request(this._options, this._onNativeResponse);
+  } catch (err) {
+    this.emit("error", err);
+    return;
+  }
   this._currentUrl = url.format(this._options);
 
   // Set up event handlers


### PR DESCRIPTION
Native request in special circumstances throw errors like `ERR_UNESCAPED_CHARACTERS`, `ERR_INVALID_PROTOCOL`, `ERR_INVALID_ARG_TYPE`, `ERR_INVALID_HTTP_TOKEN` etc.

This will make sure that these errors are handled properly.
