### PR TITLE
Declare debug as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,14 @@
       "url": "https://github.com/sponsors/RubenVerborgh"
     }
   ],
+  "peerDependencies": {
+    "debug": "^3.0.0 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "debug": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "concat-stream": "^2.0.0",
     "eslint": "^5.16.0",


### PR DESCRIPTION
Related: #135.

npm (https://github.com/npm/cli/pull/224) and Yarn supports `peerDependenciesMeta` field in the `pakcage.json`, which allows to mark a peer dependency as optional.