### PR TITLE
Declare `debug` as optional using `peerDependenciesMeta`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
       "url": "https://github.com/sponsors/RubenVerborgh"
     }
   ],
-  "peerDependencies": {
-    "debug": "^3.0.0 || ^4.0.0"
-  },
   "peerDependenciesMeta": {
     "debug": {
       "optional": true

--- a/package.json
+++ b/package.json
@@ -43,6 +43,14 @@
       "url": "https://github.com/sponsors/RubenVerborgh"
     }
   ],
+  "peerDependencies": {
+    "debug": "^3.0.0 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "debug": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "concat-stream": "^2.0.0",
     "eslint": "^5.16.0",


### PR DESCRIPTION
Related: #135 and #140.

This will result in:
- no change in package managers that don't support `peerDependenciesMeta` **EDIT (Aug. 16):** without `peerDependencies` declaration
- no warning for undeclared peer dependency, especially in Yarn 2 with PnP

so it's completely backward compatible.