### PR TITLE
fix crash when http/https libraries use getters

### DIFF
--- a/index.js
+++ b/index.js
@@ -400,7 +400,7 @@ function wrap(protocols) {
     var wrappedProtocol = exports[scheme] = Object.create(nativeProtocol);
 
     // Executes a request, following redirects
-    wrappedProtocol.request = function (input, options, callback) {
+    function request(input, options, callback) {
       // Parse parameters
       if (typeof input === "string") {
         var urlStr = input;
@@ -435,14 +435,20 @@ function wrap(protocols) {
       assert.equal(options.protocol, protocol, "protocol mismatch");
       debug("options", options);
       return new RedirectableRequest(options, callback);
-    };
+    }
 
     // Executes a GET request, following redirects
-    wrappedProtocol.get = function (input, options, callback) {
-      var request = wrappedProtocol.request(input, options, callback);
-      request.end();
-      return request;
-    };
+    function get(input, options, callback) {
+      var wrappedRequest = wrappedProtocol.request(input, options, callback);
+      wrappedRequest.end();
+      return wrappedRequest;
+    }
+
+    // Expose the properties on the wrapped protocol
+    Object.defineProperties(wrappedProtocol, {
+      request: { value: request, configurable: true, enumerable: true, writable: true },
+      get: { value: get, configurable: true, enumerable: true, writable: true },
+    });
   });
   return exports;
 }


### PR DESCRIPTION
If this library is bundled and the bundler shims the `http` and `https` libraries such that the properties are exposed via getters instead of properties, this library will crash with the following error:

```
      wrappedProtocol.request = function(input, options, callback) {
                              ^
TypeError: Cannot set property request of #<Object> which has only a getter
```

This happens because assigning over an existing property in the prototype chain with a getter attempts to call the setter, which doesn't exist. This problem can be avoided by using `Object.defineProperty` instead of the assignment operator to implement the override.

This issue was reported to me on a repository of mine: https://github.com/evanw/esbuild/issues/587. The fix was simple so I figured I'd send you a PR. I don't mind if you don't want to fix this. Arguably it's a problem with the bundler, not with this library. But making the change in this PR will make your library more portable in use cases such as this.
