### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 sudo: false
-
+arch:
+  - amd64
+  - ppc64le
 node_js:
   - '4'
   - '6.0'


### PR DESCRIPTION
Hi,
I had added ppc64le support on Travis-ci and Its been success added and build. Kindly review and merge same.

Changes done are added ppc64le arch.

The Travis ci build logs can be verified from the link below.
https://travis-ci.com/github/zazzel/follow-redirects
Please have a look.

Thank you
