### PR TITLE
make 'debug' as dependencies

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -1,9 +1,3 @@
-var debug;
-try {
-  /* eslint global-require: off */
-  debug = require("debug")("follow-redirects");
-}
-catch (error) {
-  debug = function () { /* */ };
-}
+var debug = require("debug")("follow-redirects");
+
 module.exports = debug;

--- a/package-lock.json
+++ b/package-lock.json
@@ -494,12 +494,11 @@
       }
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -1656,8 +1655,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,8 @@
       "url": "https://github.com/sponsors/RubenVerborgh"
     }
   ],
-  "peerDependenciesMeta": {
-    "debug": {
-      "optional": true
-    }
+  "dependencies": {
+    "debug": "^4.3.1"
   },
   "devDependencies": {
     "concat-stream": "^2.0.0",


### PR DESCRIPTION
nodejs between v11.x - v15.5.1 has a bug: it will cache MODULE_NOT_FOUND when require a non-exits file([issue](nodejs/node#26926)). 

./debug.js try to require('debug'), if the 'debug' pkg not exits, nodejs will cache the result. Even install debug later in the same process(spawn npm install), require('debug') will still throw error

so, we should make 'debug' pacakge as dependencies.