### PR TITLE
解决由包含特殊字符的重定向URL导致的乱码。

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,7 +358,12 @@ RedirectableRequest.prototype._processResponse = function (response) {
       url.parse(this._currentUrl).hostname;
 
     // Create the redirected request
-    var redirectUrl = url.resolve(this._currentUrl, location);
+
+    // from https://github.com/sindresorhus/got/blob/780550124d0de468c1c0704b26673b1d21de86d3/source/core/index.ts#L741
+    // We need this in order to support UTF-8
+    var redirectBuffer = Buffer.from(response.headers.location, "binary").toString();
+    var redirectUrl = url.resolve(this._currentUrl, redirectBuffer);
+    
     debug("redirecting to", redirectUrl);
     this._isRedirect = true;
     var redirectUrlParts = url.parse(redirectUrl);


### PR DESCRIPTION
如果跳转的网址包含特殊字符就会导致乱码。

![QQ截图20210807112827.png](https://i.loli.net/2021/08/07/sVW1hcdywRU3l2t.png)

我在got库中发现了这段代码。可以有效的解决这个问题。

![20210807112928.png](https://i.loli.net/2021/08/07/MQgqlU157FwVTIc.png)

https://github.com/sindresorhus/got/blob/main/source/core/index.ts#L741
这会使测试 "emits an error on redirects with an invalid location" 失效。
所以变更为了"redirect response contains UTF-8 with binary encoding"
来自 https://github.com/sindresorhus/got/blob/780550124d0de468c1c0704b26673b1d21de86d3/test/redirects.ts#L263

  103 passing (778ms)

File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |      100 |      100 |      100 |      100 |                   |
 index.js |      100 |      100 |      100 |      100 |                   |
----------|----------|----------|----------|----------|-------------------|