### PR TITLE
use existing host header when possible

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1243,7 +1243,7 @@ describe("follow-redirects", function () {
         });
     });
 
-    it("uses the existing host header if redirect host is the same", function () {
+    it("uses the location host if redirect host is the same", function () {
       app.get("/a", redirectsTo(302, "http://localhost:3600/b"));
       app.get("/b", function (req, res) {
         res.write(JSON.stringify(req.headers));
@@ -1282,7 +1282,7 @@ describe("follow-redirects", function () {
         }))
         .then(asPromise(function (resolve, reject, res) {
           assert.deepEqual(res.statusCode, 200);
-          assert.deepEqual(res.responseUrl, "http://127.0.0.1:3600/b");
+          assert.deepEqual(res.responseUrl, "http://localhost:3600/b");
           res.pipe(concat({ encoding: "string" }, resolve)).on("error", reject);
         }))
         .then(function (str) {
@@ -1341,6 +1341,32 @@ describe("follow-redirects", function () {
           var body = JSON.parse(str);
           assert.equal(body.host, "localhost:3600");
           assert.equal(body.authorization, "bearer my-token-1234");
+        });
+    });
+
+    it("drops the header when redirected to a different host (same hostname and different port)", function () {
+      app.get("/a", redirectsTo(302, "http://localhost:3600/b"));
+      app.get("/b", function (req, res) {
+        res.end(JSON.stringify(req.headers));
+      });
+
+      var opts = url.parse("http://127.0.0.1:3600/a");
+      opts.headers = {
+        host: "localhost",
+        authorization: "bearer my-token-1234",
+      };
+
+      return server.start(app)
+        .then(asPromise(function (resolve, reject) {
+          http.get(opts, resolve).on("error", reject);
+        }))
+        .then(asPromise(function (resolve, reject, res) {
+          res.pipe(concat({ encoding: "string" }, resolve)).on("error", reject);
+        }))
+        .then(function (str) {
+          var body = JSON.parse(str);
+          assert.equal(body.host, "localhost:3600");
+          assert.equal(body.authorization, undefined);
         });
     });
 


### PR DESCRIPTION
- Remove Host header only if redirecting to a new host.
- Clarify logic to operate on full host instead of hostname to keep/remove Host and Authorization headers. Host header is hostname+port. previousHostName could have been a Host or a Hostname.

Our company uses a dns caching library and makes requests by ip with the original hostname in the Host header. When following a redirect that Host header was removed always and for https requests this caused an SSL SAN error because the certificate SAN did not match IP.
```
subjectAltName does not match 111.111.111.111
SSL: no alternative certificate subject name matches target host name '111.111.111.111'
```
This change is to remove the configured Host header only if the redirect does not use the same host so that the configured Host header will be used to follow redirects when possible.

Further clarification of the problem this PR addresses:
1. Service uses DNS cache to submit request by IP.
```
https://111.111.111.111/old/path
- H "Host: example.com"
```
2. Server responds with redirect
```
- H "location: https://111.111.111.111/new/path"
or
- H "location: /new/path"
```
Previously the follow redirects library would request:
```
https://111.111.111.111/new/path
```
This would cause an error with https because host would not match the subject alt name in the certificate.

Changes in this PR will cause the new request to use the existing host header if the host does not change (both cases of same host in redirect (match determined by Host header if exists) or relative redirect):
```
https://111.111.111.111/new/path
- H "Host: example.com"
```
