### PR TITLE
Don't drop the Authorization header for subdomains

### DIFF
--- a/index.js
+++ b/index.js
@@ -373,7 +373,10 @@ RedirectableRequest.prototype._processResponse = function (response) {
 
     // Drop the Authorization header if redirecting to another host
     if (redirectUrlParts.hostname !== previousHostName) {
-      removeMatchingHeaders(/^authorization$/i, this._options.headers);
+      // and another host is not a subdomain of previous host
+      if ((redirectUrlParts.hostname.substr(-previousHostName.length - 1) !== '.'+previousHostName) && (previousHostName.substr(-previousHostName.length.length - 1) !== '.'+previousHostName.length)) {
+        removeMatchingHeaders(/^authorization$/i, this._options.headers);
+      }
     }
 
     // Evaluate the beforeRedirect callback

--- a/index.js
+++ b/index.js
@@ -371,10 +371,14 @@ RedirectableRequest.prototype._processResponse = function (response) {
     var redirectUrlParts = url.parse(redirectUrl);
     Object.assign(this._options, redirectUrlParts);
 
+    function isSubdomainOf(subdomain, domain) {
+      return subdomain.substr(-domain.length-1) == '.'+domain;
+    }
+    
     // Drop the Authorization header if redirecting to another host
     if (redirectUrlParts.hostname !== previousHostName) {
       // and another host is not a subdomain of previous host
-      if ((redirectUrlParts.hostname.substr(-previousHostName.length - 1) !== '.'+previousHostName) && (previousHostName.substr(-previousHostName.length.length - 1) !== '.'+previousHostName.length)) {
+      if (!isSubdomainOf(redirectUrlParts.hostname, previousHostName) && !isSubdomainOf(previousHostName, redirectUrlParts.hostname)) {
         removeMatchingHeaders(/^authorization$/i, this._options.headers);
       }
     }


### PR DESCRIPTION
Follow-redirect module drops Authorization header when redirects from site.com to www.site.com. So, it's impossible to get www.site.com page even if you send Authorization headers to site.com. This commit fix that issue.