### PR TITLE
feat: pass response status & request details to beforeRedirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ const { http, https } = require('follow-redirects');
 
 const options = url.parse('http://bit.ly/900913');
 options.maxRedirects = 10;
-options.beforeRedirect = (options, { headers, statusCode, requestUrl }) => {
+options.beforeRedirect = (options, { headers, statusCode, requestMethod, requestUrl }) => {
   // Use this to adjust the request options upon redirecting,
   // to inspect the latest response headers,
   // or to cancel the request by throwing an error
+
   // headers = the redirect response headers
   // statusCode = the redirect response code (eg. 301, 307, etc.)
+  // requestMethod = the request method that resulted in a redirect
   // requestUrl = the requested URL that resulted in a redirect
   if (options.hostname === "example.com") {
     options.auth = "user:password";

--- a/README.md
+++ b/README.md
@@ -63,15 +63,16 @@ const { http, https } = require('follow-redirects');
 
 const options = url.parse('http://bit.ly/900913');
 options.maxRedirects = 10;
-options.beforeRedirect = (options, { headers, statusCode, requestMethod, requestUrl }) => {
+options.beforeRedirect = (options, { headers, statusCode }, { method, url }) => {
   // Use this to adjust the request options upon redirecting,
   // to inspect the latest response headers,
   // or to cancel the request by throwing an error
 
   // headers = the redirect response headers
   // statusCode = the redirect response code (eg. 301, 307, etc.)
-  // requestMethod = the request method that resulted in a redirect
-  // requestUrl = the requested URL that resulted in a redirect
+
+  // method = the request method that resulted in a redirect
+  // url = the requested URL that resulted in a redirect
   if (options.hostname === "example.com") {
     options.auth = "user:password";
   }

--- a/README.md
+++ b/README.md
@@ -63,10 +63,13 @@ const { http, https } = require('follow-redirects');
 
 const options = url.parse('http://bit.ly/900913');
 options.maxRedirects = 10;
-options.beforeRedirect = (options, { headers }) => {
+options.beforeRedirect = (options, { headers, statusCode, requestUrl }) => {
   // Use this to adjust the request options upon redirecting,
   // to inspect the latest response headers,
   // or to cancel the request by throwing an error
+  // headers = the redirect response headers
+  // statusCode = the redirect response code (eg. 301, 307, etc.)
+  // requestUrl = the requested URL that resulted in a redirect
   if (options.hostname === "example.com") {
     options.auth = "user:password";
   }

--- a/index.js
+++ b/index.js
@@ -414,7 +414,11 @@ RedirectableRequest.prototype._processResponse = function (response) {
 
   // Evaluate the beforeRedirect callback
   if (typeof this._options.beforeRedirect === "function") {
-    var responseDetails = { headers: response.headers };
+    var responseDetails = {
+      headers: response.headers,
+      statusCode: statusCode,
+      requestUrl: currentUrl,
+    };
     try {
       this._options.beforeRedirect.call(null, this._options, responseDetails);
     }

--- a/index.js
+++ b/index.js
@@ -366,6 +366,7 @@ RedirectableRequest.prototype._processResponse = function (response) {
   // care for methods not known to be safe, […]
   // RFC7231§6.4.2–3: For historical reasons, a user agent MAY change
   // the request method from POST to GET for the subsequent request.
+  var originalRequestMethod = this._options.method;
   if ((statusCode === 301 || statusCode === 302) && this._options.method === "POST" ||
       // RFC7231§6.4.4: The 303 (See Other) status code indicates that
       // the server is redirecting the user agent to a different resource […]
@@ -417,6 +418,7 @@ RedirectableRequest.prototype._processResponse = function (response) {
     var responseDetails = {
       headers: response.headers,
       statusCode: statusCode,
+      requestMethod: originalRequestMethod,
       requestUrl: currentUrl,
     };
     try {

--- a/index.js
+++ b/index.js
@@ -366,7 +366,7 @@ RedirectableRequest.prototype._processResponse = function (response) {
   // care for methods not known to be safe, […]
   // RFC7231§6.4.2–3: For historical reasons, a user agent MAY change
   // the request method from POST to GET for the subsequent request.
-  var originalRequestMethod = this._options.method;
+  var method = this._options.method;
   if ((statusCode === 301 || statusCode === 302) && this._options.method === "POST" ||
       // RFC7231§6.4.4: The 303 (See Other) status code indicates that
       // the server is redirecting the user agent to a different resource […]
@@ -414,15 +414,18 @@ RedirectableRequest.prototype._processResponse = function (response) {
   }
 
   // Evaluate the beforeRedirect callback
-  if (typeof this._options.beforeRedirect === "function") {
+  var beforeRedirect = this._options.beforeRedirect;
+  if (typeof beforeRedirect === "function") {
     var responseDetails = {
       headers: response.headers,
       statusCode: statusCode,
-      requestMethod: originalRequestMethod,
-      requestUrl: currentUrl,
+    };
+    var requestDetails = {
+      method: method,
+      url: currentUrl,
     };
     try {
-      this._options.beforeRedirect.call(null, this._options, responseDetails);
+      beforeRedirect(this._options, responseDetails, requestDetails);
     }
     catch (err) {
       this.emit("error", err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "follow-redirects",
       "version": "1.14.9",
       "funding": [
         {

--- a/test/test.js
+++ b/test/test.js
@@ -1628,8 +1628,8 @@ describe("follow-redirects", function () {
             port: 3600,
             path: "/a",
             method: "POST",
-            beforeRedirect: function (_, response) {
-              requestMethods.push(response.requestMethod);
+            beforeRedirect: function (_, __, request) {
+              requestMethods.push(request.method);
             },
           };
           http.get(options, concatJson(resolve, reject)).on("error", reject);
@@ -1655,8 +1655,8 @@ describe("follow-redirects", function () {
             port: 3600,
             path: "/a",
             method: "GET",
-            beforeRedirect: function (_, response) {
-              urlChain.push(response.requestUrl);
+            beforeRedirect: function (_, __, request) {
+              urlChain.push(request.url);
             },
           };
           http.get(options, concatJson(resolve, reject)).on("error", reject);

--- a/test/test.js
+++ b/test/test.js
@@ -1581,6 +1581,67 @@ describe("follow-redirects", function () {
           assert.equal(body[header.toLowerCase()], undefined);
         });
     });
+
+    it("passes the redirect status code to beforeRedirect", function () {
+      app.get("/a", redirectsTo("/b"));
+      app.get("/b", redirectsTo("/c", 301));
+      app.get("/c", redirectsTo("/d", 302));
+      app.get("/d", redirectsTo("/e", 303));
+      app.get("/e", redirectsTo("/f", 307));
+      app.get("/f", redirectsTo("/g", 308));
+      app.get("/g", sendsJson({ a: "b" }));
+
+      const statusCodes = [];
+
+      return server.start(app)
+        .then(asPromise(function (resolve, reject) {
+          var options = {
+            host: "localhost",
+            port: 3600,
+            path: "/a",
+            method: "GET",
+            beforeRedirect: function (_, response) {
+              statusCodes.push(response.statusCode);
+            },
+          };
+          http.get(options, concatJson(resolve, reject)).on("error", reject);
+        }))
+        .then(function (res) {
+          assert.deepEqual(res.responseUrl, "http://localhost:3600/g");
+          assert.deepEqual(res.parsedJson, { a: "b" });
+          assert.deepEqual(statusCodes, [302, 301, 302, 303, 307, 308]);
+        });
+    });
+
+    it("passes the original request URL to beforeRedirect", function () {
+      app.get("/a", redirectsTo("/b"));
+      app.get("/b", redirectsTo("/c"));
+      app.get("/c", sendsJson({ a: "b" }));
+
+      const urlChain = [];
+
+      return server.start(app)
+        .then(asPromise(function (resolve, reject) {
+          var options = {
+            host: "localhost",
+            port: 3600,
+            path: "/a",
+            method: "GET",
+            beforeRedirect: function (_, response) {
+              urlChain.push(response.requestUrl);
+            },
+          };
+          http.get(options, concatJson(resolve, reject)).on("error", reject);
+        }))
+        .then(function (res) {
+          assert.deepEqual(res.responseUrl, "http://localhost:3600/c");
+          assert.deepEqual(res.parsedJson, { a: "b" });
+          assert.deepEqual(urlChain, [
+            "http://localhost:3600/a",
+            "http://localhost:3600/b",
+          ]);
+        });
+    });
   });
 
   describe("when the followRedirects option is set to false", function () {


### PR DESCRIPTION
I have a couple of use cases† that require the `beforeRedirect` hook to be aware of the requested URL that is resulting in the redirect. I also noted that in #191 @SergeBabich wanted to add the redirect status code, but hadn’t provided tests.

This PR adds both these to the response details object passed to `beforeRedirect`.

**Update (1aa5e3c)** - I also include the request method.
**Update (9771127)** - Moved URL and method to a third “request details” param
**Update (f63ebbc)** - Added the request headers to the third param

† I need to store cookies returned across a chain of redirects, as well as to record some forensics about each individual request/response in the chain.