### PR TITLE
fix: Protects Error.captureStackTrace for non-compatible browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -615,7 +615,9 @@ function removeMatchingHeaders(regex, headers) {
 function createErrorType(code, message, baseClass) {
   // Create constructor
   function CustomError(properties) {
-    Error.captureStackTrace(this, this.constructor);
+    if(Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
     Object.assign(this, properties || {});
     this.code = code;
     this.message = this.cause ? message + ": " + this.cause.message : message;


### PR DESCRIPTION
Hi!

We've detected that 1.15.4 is crashing at Safari browser because of the use of Error.captureStackTrace.
We propose to protect just with an if statement but if you think that there is an smarter mechanism feel free to proceed.

Thank you!