### PR TITLE
fix: re-add missing URL `hash` field

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ var preservedUrlFields = [
   "protocol",
   "query",
   "search",
+  "hash"
 ];
 
 // Create handlers that pass events from native requests


### PR DESCRIPTION
This appears to be a simple oversight from https://github.com/follow-redirects/follow-redirects/commit/05629af696588b90d64e738bc2e809a97a5f92fc where the `preservedUrlFields` list was added but without the `hash` property.