### PR TITLE
Ensure that binary characters are escaped correctly in the location header

### DIFF
--- a/index.js
+++ b/index.js
@@ -567,6 +567,8 @@ function parseUrl(input) {
 }
 
 function resolveUrl(relative, base) {
+  // Ensure that any non-ascii characters are escaped correctly as a valid URI
+  relative = encodeURI(Buffer.from(relative, 'binary').toString('utf8'))
   /* istanbul ignore next */
   return useNativeURL ? new URL(relative, base) : parseUrl(url.resolve(base, relative));
 }


### PR DESCRIPTION
I'm seeing the issue #125 on the following URLs, because the server returns binary characters in the location header.
- https://chromewebstore.google.com/detail/aeblfdkhhhdcdjpifhhbdiojplfjncoa
- https://chromewebstore.google.com/detail/fdjamakpfbbddfjaooikfcpapjohcfmg

These URLs redirect correctly on curl, Firefox, Chrome, and a few other cli tools and scripts that I tried. I was also able to use `https.get` by manually converting the binary string in the location header to utf-8, and then doing an `encodeURI` on it like this:

```javascript
import https from 'node:https';
import { parse } from 'node:url';

const url = 'https://chromewebstore.google.com/detail/aeblfdkhhhdcdjpifhhbdiojplfjncoa';
const headers = {
	'User-Agent':
		'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
};

https.get({ ...parse(url), headers }, (response1) => {
	const location = encodeURI(Buffer.from(response1.headers.location, 'binary').toString('utf8'));
	https.get({ ...parse(location), headers }, ({ statusCode }) => {
		console.log(statusCode);
	});
});
```

So, I've ported over the fix, and added a test for it.
