### PR TITLE
Propagate basic auth info when using native URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .nyc_output
 node_modules
+.worktrees

--- a/index.js
+++ b/index.js
@@ -587,6 +587,12 @@ function spreadUrlObject(urlObject, target) {
     spread[key] = urlObject[key];
   }
 
+  // Native URL objects don't include an `auth` field, but the http and https
+  // protocols rely on that to create the Authorization header
+  if (useNativeURL && urlObject.username && urlObject.password && !urlObject.auth) {
+    spread.auth = `${decodeURIComponent(urlObject.username)}:${decodeURIComponent(urlObject.password)}`;
+  }
+
   // Fix IPv6 hostname
   if (spread.hostname.startsWith("[")) {
     spread.hostname = spread.hostname.slice(1, -1);

--- a/test/test.js
+++ b/test/test.js
@@ -97,6 +97,99 @@ describe("follow-redirects", function () {
       });
   });
 
+  describe("basic auth propagation", function () {
+    it("propagates basic auth from native URL through redirect", function () {
+      if (nodeMajorVersion < 10) {
+        this.skip();
+      }
+
+      app.get("/a", redirectsTo("/b"));
+      app.get("/b", function (req, res) {
+        res.end(JSON.stringify(req.headers));
+      });
+
+      return server.start(app)
+        .then(asPromise(function (resolve, reject) {
+          http.get(new URL("http://user:pass@localhost:3600/a"), resolve).on("error", reject);
+        }))
+        .then(asPromise(function (resolve, reject, res) {
+          res.pipe(concat({ encoding: "string" }, resolve)).on("error", reject);
+        }))
+        .then(function (str) {
+          var body = JSON.parse(str);
+          var expected = Buffer.from("user:pass").toString("base64");
+          assert.equal(body.authorization, "Basic " + expected);
+        });
+    });
+
+    it("propagates basic auth with encoded special characters from native URL", function () {
+      if (nodeMajorVersion < 10) {
+        this.skip();
+      }
+
+      app.get("/a", redirectsTo("/b"));
+      app.get("/b", function (req, res) {
+        res.end(JSON.stringify(req.headers));
+      });
+
+      return server.start(app)
+        .then(asPromise(function (resolve, reject) {
+          http.get(new URL("http://user%40user.com:bar%3A@localhost:3600/a"), resolve).on("error", reject);
+        }))
+        .then(asPromise(function (resolve, reject, res) {
+          res.pipe(concat({ encoding: "string" }, resolve)).on("error", reject);
+        }))
+        .then(function (str) {
+          var body = JSON.parse(str);
+          var expected = Buffer.from("user@user.com:bar:").toString("base64");
+          assert.equal(body.authorization, "Basic " + expected);
+        });
+    });
+
+    it("propagates basic auth from url.parse through redirect", function () {
+      app.get("/a", redirectsTo("/b"));
+      app.get("/b", function (req, res) {
+        res.end(JSON.stringify(req.headers));
+      });
+
+      return server.start(app)
+        .then(asPromise(function (resolve, reject) {
+          http.get(url.parse("http://user:pass@localhost:3600/a"), resolve).on("error", reject);
+        }))
+        .then(asPromise(function (resolve, reject, res) {
+          res.pipe(concat({ encoding: "string" }, resolve)).on("error", reject);
+        }))
+        .then(function (str) {
+          var body = JSON.parse(str);
+          var expected = Buffer.from("user:pass").toString("base64");
+          assert.equal(body.authorization, "Basic " + expected);
+        });
+    });
+
+    it("does not send auth header when native URL has no credentials", function () {
+      if (nodeMajorVersion < 10) {
+        this.skip();
+      }
+
+      app.get("/a", redirectsTo("/b"));
+      app.get("/b", function (req, res) {
+        res.end(JSON.stringify(req.headers));
+      });
+
+      return server.start(app)
+        .then(asPromise(function (resolve, reject) {
+          http.get(new URL("http://localhost:3600/a"), resolve).on("error", reject);
+        }))
+        .then(asPromise(function (resolve, reject, res) {
+          res.pipe(concat({ encoding: "string" }, resolve)).on("error", reject);
+        }))
+        .then(function (str) {
+          var body = JSON.parse(str);
+          assert.equal(body.authorization, undefined);
+        });
+    });
+  });
+
   it("http.get with options object and callback - redirect", function () {
     app.get("/a", redirectsTo("/b"));
     app.get("/b", redirectsTo("/c"));


### PR DESCRIPTION
Fixes #243 

Tested via node 16.18.1 (which uses native URL, ie `useNativeURL == true`) and a local axios install.
`await axios.get("https://httpbin.org/redirect-to?url=%2Fbasic-auth%2Fuser%2540user.com%2Fbar%253A&status_code=301", {auth:{username:'user@user.com', password:'bar:'}})` successfully authenticated with the change, and fails without it.

I may need some help getting test coverage, as there's no existing utility function for performing authenticated requests (and I don't have a lot of time to devote to this effort).