### PR TITLE
Assert that follow-redirects isn't running in a browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ var Writable = require("stream").Writable;
 var assert = require("assert");
 var debug = require("./debug");
 
+// follow-redirects must not be used in browsers because the browser
+// equivalents perform redirects by default
+assert(typeof window === "undefined")
+
 // Whether to use the native URL object or the legacy url module
 var useNativeURL = false;
 try {


### PR DESCRIPTION
I see follow-redirects being used on commerzbank.de (https://bugzilla.mozilla.org/show_bug.cgi?id=1913691) and myxera.pro (https://bugzilla.mozilla.org/show_bug.cgi?id=1913687) This causes compatibility problems for Firefox because it does not implement Error.captureStackTrace.

I fixed this to use `typeof window === "undefined"` instead of `window === "undefined"`